### PR TITLE
Fix deprecation error in DateTime

### DIFF
--- a/includes/Mailer/class-rest.php
+++ b/includes/Mailer/class-rest.php
@@ -130,7 +130,7 @@ class Rest {
 		$contents = wp_json_encode( $args );
 		$md5      = md5( $contents );
 
-		$datetime  = new \DateTime( null, new \DateTimeZone( 'Europe/Helsinki' ) );
+		$datetime  = new \DateTime( 'now', new \DateTimeZone( 'Europe/Helsinki' ) );
 		$timestamp = $datetime->format( 'c' );
 		$type      = 'POST';
 		$url       = $this->api_url . '/api/v' . $this->api_version . '/' . $method;


### PR DESCRIPTION
Fixes `DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /wordpress/wp-content/plugins/lianamailer-gf/includes/Mailer/class-rest.php on line 133` error by using `'now'` instead of `null` as first param for `DateTime`