### PR TITLE
Fix: Use 'now' instead of null in DateTime constructor

### DIFF
--- a/includes/Mailer/class-rest.php
+++ b/includes/Mailer/class-rest.php
@@ -130,7 +130,9 @@ class Rest {
 		$contents = wp_json_encode( $args );
 		$md5      = md5( $contents );
 
-		$datetime  = new \DateTime( null, new \DateTimeZone( 'Europe/Helsinki' ) );
+		// Use 'now' to initialize DateTime with the current date and time
+		// Or Pass empty string instead ('')
+		$datetime  = new \DateTime( 'now', new \DateTimeZone( 'Europe/Helsinki' ) );
 		$timestamp = $datetime->format( 'c' );
 		$type      = 'POST';
 		$url       = $this->api_url . '/api/v' . $this->api_version . '/' . $method;


### PR DESCRIPTION
This pull request addresses an issue in the Mailer REST class where the DateTime constructor was called with an incorrect parameter.

#### Quick fix changes made:

- Modified `includes/Mailer/class-rest.php`
- Changed `new \\DateTime( null, new \\DateTimeZone( 'Europe/Helsinki' ) )` to `new \\DateTime( 'now', new \\DateTimeZone( 'Europe/Helsinki' ) )`

This fix ensures that the DateTime object is correctly initialized with the current time in the specified timezone.

#### Potential Optimization

While the current fix resolves the immediate issue, there's potential for further optimization. This could use `gmdate('c')` to get the current timestamp in the 'Europe/Helsinki' timezone instead of creating a new DateTime object on each call:

```php
// Set the default timezone to 'Europe/Helsinki'
date_default_timezone_set('Europe/Helsinki');

// Use gmdate() to get the current timestamp in ISO 8601 format
$timestamp = gmdate('c');
```

Fixes [#4](https://github.com/LianaTechnologies/lianamailer-gf/issues/4) related issue