### PR TITLE
Fix html in consent label breaking the page

### DIFF
--- a/includes/class-gf-field-lianamailer.php
+++ b/includes/class-gf-field-lianamailer.php
@@ -191,7 +191,7 @@ class GF_Field_LianaMailer extends \GF_Field {
 		$required_attribute = $this->isRequired ? 'aria-required="true"' : '';
 		// phpcs:ignore
 		$required_div       = $this->isRequired ? '<span class="gfield_required">' . $this->get_required_indicator() . '</span>' : '';
-		$data_consent_label = ( $consent_id && $choice['text'] ? "data-consent-label='{$choice['text']}'" : '' );
+		$data_consent_label = ( $consent_id && $choice['text'] ? 'data-consent-label="' . esc_attr( $choice['text'] ) . '"' : '' );
 
 		$choice_markup = "<input name='input_{$input_id}' type='checkbox' value='{$choice_value}' {$checked} id='choice_{$id}' {$tabindex} {$disabled_text} {$required_attribute} />
                         <label for='choice_{$id}' id='label_{$id}' {$data_consent_label}>{$choice['text']} {$required_div}</label>";


### PR DESCRIPTION
If the consent label contains HTML, markup will break and cause damage to the rest of the page.

So, for example label like this breaks the site.
```html
<p>Hyväksyn tietojeni tallentamisen ja käsittelyn <a href="https://domain.fi" target="_blank" rel="noopener noreferrer">tietosuojaselosteen</a> mukaisesti</p>
```

What happens with that label is that much of the following HTML gets appended to the `data-consent-label`. By escaping the attribute, we encode the characters that might cause problems and have made the world a bit better.