### PR TITLE
Add support for conditional logic, name field subfields and admin label

### DIFF
--- a/includes/class-gf-field-lianamailer.php
+++ b/includes/class-gf-field-lianamailer.php
@@ -411,7 +411,7 @@ class GF_Field_LianaMailer extends \GF_Field {
 		$field_icon = '<span class="gfield-field-action gfield-icon">' . \GFCommon::get_icon_markup( array( 'icon' => $this->get_form_editor_field_icon() ) ) . '</span>';
 
 		$admin_buttons = "
-			<div class='gfield-admin-icons'>
+			<div class='gfield-admin-icons gform-theme__disable'>
 				{$drag_handle}
 				{$edit_field_link}
 				{$delete_field_link}

--- a/includes/class-gf-field-lianamailer.php
+++ b/includes/class-gf-field-lianamailer.php
@@ -454,6 +454,7 @@ class GF_Field_LianaMailer extends \GF_Field {
 			// Advanced Tab
 			'admin_label_setting',
 			'visibility_setting',
+			'conditional_logic_field_setting',
 		);
 	}
 }

--- a/includes/class-gf-field-lianamailer.php
+++ b/includes/class-gf-field-lianamailer.php
@@ -200,8 +200,8 @@ class GF_Field_LianaMailer extends \GF_Field {
 		$required_div       = $this->isRequired ? '<span class="gfield_required">' . $this->get_required_indicator() . '</span>' : '';
 		$data_consent_label = ( $consent_id && $choice['text'] ? 'data-consent-label="' . esc_attr( $choice['text'] ) . '"' : '' );
 
-		$choice_markup = "<input name='input_{$input_id}' type='checkbox' value='{$choice_value}' {$checked} id='choice_{$id}' {$tabindex} {$disabled_text} {$required_attribute} />
-                        <label for='choice_{$id}' id='label_{$id}' {$data_consent_label}>{$choice['text']} {$required_div}</label>";
+		$choice_markup = "<input name='input_{$input_id}' type='checkbox' value='{$choice_value}' {$checked} id='input_{$id}' {$tabindex} {$disabled_text} {$required_attribute} />
+                        <label for='input_{$id}' id='label_{$id}' {$data_consent_label}>{$choice['text']} {$required_div}</label>";
 
 		if ( $is_admin && ! empty( $notice_msgs ) ) {
 			$choice_markup     .= '<div class="notices">';
@@ -456,5 +456,14 @@ class GF_Field_LianaMailer extends \GF_Field {
 			'visibility_setting',
 			'conditional_logic_field_setting',
 		);
+	}
+
+	/**
+	 * Enables conditional logic based on this field.
+	 *
+	 * @return bool
+	 */
+	public function is_conditional_logic_supported() {
+		return true;
 	}
 }

--- a/includes/class-gf-field-lianamailer.php
+++ b/includes/class-gf-field-lianamailer.php
@@ -93,7 +93,7 @@ class GF_Field_LianaMailer extends \GF_Field {
 			'precheck'               => false,
 			'is_connection_valid'    => true,
 			'is_admin'               => $is_admin,
-			'is_plugin_enabled'      => false,
+			'is_plugin_enabled'      => $is_plugin_enabled,
 			'is_email_or_sms_mapped' => false,
 		);
 		$options = apply_filters( 'gform_lianamailer_get_integration_options', $options, $form_id );
@@ -101,8 +101,10 @@ class GF_Field_LianaMailer extends \GF_Field {
 		 * If plugin is not enabled, consent not selected or mailing list not selected, hide the input from public form.
 		 */
 		if ( $this->hide_input_on_public_form( $options ) ) {
+			// If the field is not required, submit empty value when hidden
+			$hidden_value = ( $this->isRequired ) ? '1' : '';
 
-			return '<input type="hidden" class="gform_hidden lianamailer_input" name="input_' . $id . '" id="' . $field_id . '" value="1" />';
+			return '<input type="hidden" class="gform_hidden lianamailer_input" name="input_' . $id . '" id="' . $field_id . '" value="' . $hidden_value . '" />';
 		}
 		return sprintf( "<div class='ginput_container ginput_container_checkbox lianamailer_input'>%s</div>", $this->get_checkbox_choices( $value, $disabled_text, $form_id, $options ) );
 	}

--- a/includes/class-gf-field-lianamailer.php
+++ b/includes/class-gf-field-lianamailer.php
@@ -441,12 +441,16 @@ class GF_Field_LianaMailer extends \GF_Field {
 	 */
 	public function get_form_editor_field_settings() {
 		return array(
-			'css_class_setting',
+			// General Tab
 			// LM Properties (select).
 			'lianamailer_properties_setting',
 			// Newsletter subscription opt-in settings. Includes checkbox and label.
 			'lianamailer_opt_in_setting',
 			'rules_setting',
+			// Appearance Tab
+			'css_class_setting',
+			// Advanced Tab
+			'admin_label_setting',
 			'visibility_setting',
 		);
 	}

--- a/includes/class-lianamailerplugin.php
+++ b/includes/class-lianamailerplugin.php
@@ -196,6 +196,13 @@ class LianaMailerPlugin {
 				if ( is_array( $inputs ) ) {
 					if ( 'name' === $input_type ) {
 						$posted_data[ $field->id ] = \GF_Fields::get( 'name' )->get_value_export( $entry, $field->id );
+
+						foreach ( $inputs as $input ) {
+							$value = rgar( $entry, (string) $input['id'] );
+							if ( ! empty( $value ) ) {
+								$posted_data[ (string) $input['id'] ] = $value;
+							}
+						}
 					} else {
 						$tmp_values = array();
 						foreach ( $inputs as $input ) {
@@ -852,6 +859,20 @@ class LianaMailerPlugin {
 						$html .= '<option value="">' . esc_html__( 'Select form field', 'lianamailer-for-gf' ) . '</option>';
 				foreach ( $form_fields as $form_field ) {
 					$html .= sprintf( '<option value="%d">%s</option>', $form_field->id, $form_field->label );
+
+					$inputs     = $form_field->get_entry_inputs();
+					$input_type = $form_field->get_input_type();
+
+					if ( 'name' === $input_type && is_array( $inputs ) ) {
+						// Add name field subfields as choices.
+						foreach ( $inputs as $input ) {
+							$html .= sprintf(
+								'<option value="%s">%s</option>',
+								$input['id'],
+								strip_tags( \GFCommon::get_label( $form_field, $input['id'] ) )
+							);
+						}
+					}
 				}
 					$html .= '</select>';
 					$html .= '</div>';

--- a/includes/class-lianamailerplugin.php
+++ b/includes/class-lianamailerplugin.php
@@ -190,18 +190,23 @@ class LianaMailerPlugin {
 			$posted_data = array();
 			foreach ( $form['fields'] as $field ) {
 
-				$inputs = $field->get_entry_inputs();
-				// If multivalued input, eg. choices. Fetch values as string imploded with ", ".
+				$inputs     = $field->get_entry_inputs();
+				$input_type = $field->get_input_type();
+				// If multivalued input, eg. choices. Fetch values as string imploded with ", " unless it's a name field.
 				if ( is_array( $inputs ) ) {
-					$tmp_values = array();
-					foreach ( $inputs as $input ) {
-						$value = rgar( $entry, (string) $input['id'] );
-						if ( ! empty( $value ) ) {
-							$tmp_values[] = $value;
+					if ( 'name' === $input_type ) {
+						$posted_data[ $field->id ] = \GF_Fields::get( 'name' )->get_value_export( $entry, $field->id );
+					} else {
+						$tmp_values = array();
+						foreach ( $inputs as $input ) {
+							$value = rgar( $entry, (string) $input['id'] );
+							if ( ! empty( $value ) ) {
+								$tmp_values[] = $value;
+							}
 						}
-					}
-					if ( ! empty( $tmp_values ) ) {
-						$posted_data[ $field->id ] = implode( ', ', $tmp_values );
+						if ( ! empty( $tmp_values ) ) {
+							$posted_data[ $field->id ] = implode( ', ', $tmp_values );
+						}
 					}
 				} else {
 					$value                     = rgar( $entry, (string) $field->id );

--- a/includes/class-lianamailerplugin.php
+++ b/includes/class-lianamailerplugin.php
@@ -864,8 +864,11 @@ class LianaMailerPlugin {
 					$input_type = $form_field->get_input_type();
 
 					if ( 'name' === $input_type && is_array( $inputs ) ) {
-						// Add name field subfields as choices.
+						// Add used name field subfields as choices.
 						foreach ( $inputs as $input ) {
+							if ( isset( $input['isHidden'] ) && $input['isHidden'] ) {
+								continue;
+							}
 							$html .= sprintf(
 								'<option value="%s">%s</option>',
 								$input['id'],


### PR DESCRIPTION
A few changes to improve use with other fields and plugins.

## Conditional logic

Enable setting admin label (eg. to "Markkinointisuostumus") so that LianaMailer field is more clear on field selection dropdowns and entry list or single entry display.

![Admin label](https://github.com/user-attachments/assets/24da8ade-a42f-4591-8c48-b92e0ba0eca6)

Allows use of conditional logic for the LianaMailer field (eg. show field if user has checked another checkbox or radio field).

Allow use of conditional logic based on the consent field (eg. show email field only if consent for LianaMailer subscription is given (not empty)).

![Conditional logic based on LianaMailer field](https://github.com/user-attachments/assets/0b6991cd-89c7-43d8-9fe9-202429900ce4)

## Better handling of the native [name field](https://docs.gravityforms.com/name/)

Use export value for name field (eg. "Frontname Surname") instead of current implementation with comma separated subfields for name field (eg. "Frontname, Surname"). 

Allow use of invidual subfields of the native name field.

![Name (full) or invidual subfields selectable for LianaMailer fields](https://github.com/user-attachments/assets/236fa36d-f204-4a94-8e05-808273eb8384)

## Minor stuff

Disable theme on admin editor so that the buttons aren't highlighted.

Use empty value if LianaMailer field is hidden and the field is not required. This prevents passing invalid consent state (`value="1"`) to other integrations (eg. feed plugins).

